### PR TITLE
Fix executeQuery method

### DIFF
--- a/src/main/java/com/livraria/dao/BaseDAO.java
+++ b/src/main/java/com/livraria/dao/BaseDAO.java
@@ -194,5 +194,16 @@ public abstract class BaseDAO<T> {
             }
             
             rs = stmt.executeQuery();
-            
-            while (
+            while (rs.next()) {
+                items.add(mapResultSetToEntity(rs));
+            }
+
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            closeResources(conn, stmt, rs);
+        }
+
+        return items;
+    }
+}


### PR DESCRIPTION
## Summary
- complete executeQuery method implementation in BaseDAO

## Testing
- `javac -d /tmp/out $(find src -name '*.java')` *(fails: reached end of file while parsing)*

------
https://chatgpt.com/codex/tasks/task_e_6849ce15f2608327a0c7d4b70d0c3d3b